### PR TITLE
fix NotificationDisplayPart.OnMouseEnter, BottomCenter support added

### DIFF
--- a/Docs/Configuration.md
+++ b/Docs/Configuration.md
@@ -112,6 +112,19 @@ Notifier notifier = new Notifier(cfg =>
 });
 ```
 
+### Notifier clear messages
+There is an option to remove notifications by theirs messages
+```csharp
+Notifier notifier = new Notifier(cfg =>
+{
+    /* * */
+});
+
+notifier.ClearMessages(); // removes all notifications
+notifier.ClearMessages("Foo"); // removes all notifications with text "Foo"
+```
+
+
 ### Message options
 ```csharp
 
@@ -120,11 +133,18 @@ using ToastNotifications.Messages.Core;
 var options =  new MessageOptions{
     FontSize = 30, // set notification font size
     ShowCloseButton = false // set the option to show or hide notification close button
+    Tag = "Any object or value which might matter in callbacks",
+    FreezeOnMouseEnter = true, // set the option to prevent notification dissapear automatically if user move cursor on it
+    ShowCloseButton = true, // set the option to show or hide close button on notifications
     NotificationClickAction = n => // set the callback for notification click event
     {
         n.Close(); // call Close method to remove notification
         notifier.ShowSuccess("clicked!");
-    }
+    },
+    CloseClickAction = n => {
+        var opts = obj.DisplayPart.GetOptions();
+        _vm.ShowInformation($"Notification close clicked, Tag: {opts.Tag}");
+    },
 };
 /* * */
 notifier.ShowError(message, options);

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ notifier.Dispose();
   ToastNotifications v2 assembies are signed. Read this doc for more details.
 
 ## Contributors
+B. Micka (https://github.com/b-mi)
 
 Uwy (https://github.com/Uwy)
 

--- a/Src/Examples/BasicUsageExample/App.xaml.cs
+++ b/Src/Examples/BasicUsageExample/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 
 namespace BasicUsageExample
 {

--- a/Src/Examples/BasicUsageExample/BasicUsageExample.csproj
+++ b/Src/Examples/BasicUsageExample/BasicUsageExample.csproj
@@ -46,7 +46,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/Examples/BasicUsageExample/BasicUsageExample.csproj
+++ b/Src/Examples/BasicUsageExample/BasicUsageExample.csproj
@@ -40,12 +40,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/Examples/BasicUsageExample/MainWindow.xaml.cs
+++ b/Src/Examples/BasicUsageExample/MainWindow.xaml.cs
@@ -12,7 +12,6 @@ namespace BasicUsageExample
         public MainWindow()
         {
             InitializeComponent();
-            //DataContext = _vm = new MainViewModel();
             _vm = new ToastViewModel();
 
             Unloaded += OnUnload;
@@ -28,43 +27,43 @@ namespace BasicUsageExample
 
         private void Button_ShowInformationClick(object sender, RoutedEventArgs e)
         {
-            showMessage(_vm.ShowInformation, "Information");
+            ShowMessage(_vm.ShowInformation, "Information");
         }
 
         private void Button_ShowSuccessClick(object sender, RoutedEventArgs e)
         {
-            showMessage(_vm.ShowSuccess, "Success");
+            ShowMessage(_vm.ShowSuccess, "Success");
         }
 
         private void Button_ShowWarningClick(object sender, RoutedEventArgs e)
         {
-            showMessage(_vm.ShowWarning, "Warning");
+            ShowMessage(_vm.ShowWarning, "Warning");
         }
 
         private void Button_ShowErrorClick(object sender, RoutedEventArgs e)
         {
-            showMessage(_vm.ShowError, "Error");
+            ShowMessage(_vm.ShowError, "Error");
         }
 
-        string lastMessage;
-        void showMessage(Action<string, MessageOptions> action, string name)
+        string _lastMessage;
+        void ShowMessage(Action<string, MessageOptions> action, string name)
         {
             MessageOptions opts = new MessageOptions
             {
-                CloseClickAction = closeAction,
+                CloseClickAction = CloseAction,
                 Tag = $"[This is Tag Value ({++_count})]",
                 FreezeOnMouseEnter = cbFreezeOnMouseEnter.IsChecked.GetValueOrDefault(),
                 ShowCloseButton = cbShowCloseButton.IsChecked.GetValueOrDefault()
             };
-            lastMessage = $"{_count} {name}";
-            action(lastMessage, opts);
+            _lastMessage = $"{_count} {name}";
+            action(_lastMessage, opts);
             bClearLast.IsEnabled = true;
         }
 
-        private void closeAction(NotificationBase obj)
+        private void CloseAction(NotificationBase obj)
         {
             var opts = obj.DisplayPart.GetOptions();
-            _vm.ShowInformation($"Notification close clicked, Tag: {opts.Tag.ToString()}");
+            _vm.ShowInformation($"Notification close clicked, Tag: {opts.Tag}");
         }
 
 
@@ -75,7 +74,7 @@ namespace BasicUsageExample
 
         private void Button_ClearLastClick(object sender, RoutedEventArgs e)
         {
-            _vm.ClearMessages(lastMessage);
+            _vm.ClearMessages(_lastMessage);
             bClearLast.IsEnabled = false;
         }
 
@@ -85,13 +84,13 @@ namespace BasicUsageExample
             _vm.ClearMessages(sameContent);
             MessageOptions opts = new MessageOptions
             {
-                CloseClickAction = closeAction,
+                CloseClickAction = CloseAction,
                 Tag = "[This is Tag Value]",
                 FreezeOnMouseEnter = cbFreezeOnMouseEnter.IsChecked.GetValueOrDefault(),
                 ShowCloseButton = cbShowCloseButton.IsChecked.GetValueOrDefault()
             };
             _vm.ShowSuccess(sameContent, opts);
-            lastMessage = sameContent;
+            _lastMessage = sameContent;
             bClearLast.IsEnabled = true;
         }
     }

--- a/Src/Examples/BasicUsageExample/ToastViewModel.cs
+++ b/Src/Examples/BasicUsageExample/ToastViewModel.cs
@@ -32,6 +32,8 @@ namespace BasicUsageExample
                 cfg.DisplayOptions.TopMost = true;
                 cfg.DisplayOptions.Width = 250;
             });
+
+            _notifier.ClearMessages();
         }
 
         public void OnUnloaded()

--- a/Src/Examples/ConfigurationExample/App.xaml.cs
+++ b/Src/Examples/ConfigurationExample/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 
 namespace ConfigurationExample
 {

--- a/Src/Examples/ConfigurationExample/ConfigurationExample.csproj
+++ b/Src/Examples/ConfigurationExample/ConfigurationExample.csproj
@@ -45,7 +45,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/Examples/ConfigurationExample/ConfigurationExample.csproj
+++ b/Src/Examples/ConfigurationExample/ConfigurationExample.csproj
@@ -39,12 +39,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/Examples/ConfigurationExample/MainViewModel.cs
+++ b/Src/Examples/ConfigurationExample/MainViewModel.cs
@@ -59,7 +59,7 @@ namespace ConfigurationExample
             {
                 case PositionProviderType.Window:
                     {
-                        return new WindowPositionProvider(Application.Current.MainWindow, corner, 25, 10);
+                        return new WindowPositionProvider(Application.Current.MainWindow, corner, 0, 0);
                     }
                 case PositionProviderType.Screen:
                     {

--- a/Src/Examples/ConfigurationExample/MainViewModel.cs
+++ b/Src/Examples/ConfigurationExample/MainViewModel.cs
@@ -104,6 +104,7 @@ namespace ConfigurationExample
             {
                 FontSize = 25,
                 ShowCloseButton = false,
+                FreezeOnMouseEnter = false,
                 NotificationClickAction = n =>
                 {
                     n.Close();
@@ -111,6 +112,7 @@ namespace ConfigurationExample
                 }
             };
 
+            
             _notifier.ShowError(message, options);
         }
         #endregion

--- a/Src/Examples/ConfigurationExample/MainViewModel.cs
+++ b/Src/Examples/ConfigurationExample/MainViewModel.cs
@@ -100,7 +100,7 @@ namespace ConfigurationExample
 
         public void ShowCustomizedMessage(string message)
         {
-            var options = new ToastNotifications.Messages.Core.MessageOptions
+            var options = new MessageOptions
             {
                 FontSize = 25,
                 ShowCloseButton = false,

--- a/Src/Examples/ConfigurationExample/MainViewModel.cs
+++ b/Src/Examples/ConfigurationExample/MainViewModel.cs
@@ -59,7 +59,7 @@ namespace ConfigurationExample
             {
                 case PositionProviderType.Window:
                     {
-                        return new WindowPositionProvider(Application.Current.MainWindow, corner, 0, 0);
+                        return new WindowPositionProvider(Application.Current.MainWindow, corner, 5, 5);
                     }
                 case PositionProviderType.Screen:
                     {

--- a/Src/Examples/CustomNotificationsExample/App.xaml.cs
+++ b/Src/Examples/CustomNotificationsExample/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 
 namespace CustomNotificationsExample
 {

--- a/Src/Examples/CustomNotificationsExample/CustomNotificationsExample.csproj
+++ b/Src/Examples/CustomNotificationsExample/CustomNotificationsExample.csproj
@@ -38,7 +38,6 @@
       <HintPath>..\..\packages\MahApps.Metro.1.5.0\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MahApps.Metro.1.5.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>
@@ -46,7 +45,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/Examples/CustomNotificationsExample/CustomNotificationsExample.csproj
+++ b/Src/Examples/CustomNotificationsExample/CustomNotificationsExample.csproj
@@ -34,20 +34,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MahApps.Metro, Version=1.4.3.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MahApps.Metro.1.4.3\lib\net45\MahApps.Metro.dll</HintPath>
+    <Reference Include="MahApps.Metro, Version=1.5.0.23, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MahApps.Metro.1.5.0\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MahApps.Metro.1.4.3\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>..\..\packages\MahApps.Metro.1.5.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/Examples/CustomNotificationsExample/packages.config
+++ b/Src/Examples/CustomNotificationsExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MahApps.Metro" version="1.4.3" targetFramework="net452" />
+  <package id="MahApps.Metro" version="1.5.0" targetFramework="net452" />
 </packages>

--- a/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml
@@ -6,7 +6,7 @@
              xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
              mc:Ignorable="d" d:DesignWidth="250" >
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource ErrorColorBrush}">
-        <Grid x:Name="Content">
+        <Grid x:Name="ContentContainer">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="25" />
                 <ColumnDefinition Width="*" />

--- a/Src/ToastNotifications.Messages/Error/ErrorMessage.cs
+++ b/Src/ToastNotifications.Messages/Error/ErrorMessage.cs
@@ -24,8 +24,7 @@ namespace ToastNotifications.Messages.Error
             if (options.FontSize != null)
                 displayPart.Text.FontSize = options.FontSize.Value;
 
-            if (options.ShowCloseButton != null)
-                displayPart.CloseButton.Visibility = options.ShowCloseButton.Value ? Visibility.Visible : Visibility.Collapsed;
+            displayPart.CloseButton.Visibility = options.ShowCloseButton ? Visibility.Visible : Visibility.Collapsed;
         }
     }
 }

--- a/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml
@@ -6,7 +6,7 @@
              xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications" 
              mc:Ignorable="d" d:DesignWidth="250"  >
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource InformationColorBrush}">
-        <Grid x:Name="Content">
+        <Grid x:Name="ContentContainer">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="25" />
                 <ColumnDefinition Width="*" />

--- a/Src/ToastNotifications.Messages/Information/InformationMessage.cs
+++ b/Src/ToastNotifications.Messages/Information/InformationMessage.cs
@@ -24,8 +24,7 @@ namespace ToastNotifications.Messages.Information
             if (options.FontSize != null)
                 displayPart.Text.FontSize = options.FontSize.Value;
 
-            if (options.ShowCloseButton != null)
-                displayPart.CloseButton.Visibility = options.ShowCloseButton.Value ? Visibility.Visible : Visibility.Collapsed;
+            displayPart.CloseButton.Visibility = options.ShowCloseButton ? Visibility.Visible : Visibility.Collapsed;
         }
     }
 }

--- a/Src/ToastNotifications.Messages/Properties/AssemblyInfo.cs
+++ b/Src/ToastNotifications.Messages/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.3.0")]
-[assembly: AssemblyFileVersion("2.1.3.0")]
+[assembly: AssemblyVersion("2.2.0")]
+[assembly: AssemblyFileVersion("2.2.0")]

--- a/Src/ToastNotifications.Messages/Properties/AssemblyInfo.cs
+++ b/Src/ToastNotifications.Messages/Properties/AssemblyInfo.cs
@@ -10,10 +10,10 @@ using System.Windows;
 [assembly: AssemblyTitle("ToastNotifications.Messages")]
 [assembly: AssemblyDescription("Toast notifications messages for WPF")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("DevCrew.pl Rafa³ £opatka")]
+[assembly: AssemblyCompany("DevCrew.pl Rafaï¿½ ï¿½opatka")]
 [assembly: AssemblyProduct("ToastNotifications.Messages")]
-[assembly: AssemblyCopyright("Copyright © Rafa³ £opatka  2017")]
-[assembly: AssemblyTrademark("Rafa³ £opatka")]
+[assembly: AssemblyCopyright("Copyright ï¿½ Rafaï¿½ ï¿½opatka  2017")]
+[assembly: AssemblyTrademark("Rafaï¿½ ï¿½opatka")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0")]
-[assembly: AssemblyFileVersion("2.2.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]

--- a/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml
@@ -6,7 +6,7 @@
              xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
              mc:Ignorable="d" d:DesignWidth="250"  >
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource SuccessColorBrush}">
-        <Grid x:Name="Content">
+        <Grid x:Name="ContentContainer">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="25" />
                 <ColumnDefinition Width="*" />

--- a/Src/ToastNotifications.Messages/Success/SuccessMessage.cs
+++ b/Src/ToastNotifications.Messages/Success/SuccessMessage.cs
@@ -24,8 +24,7 @@ namespace ToastNotifications.Messages.Success
             if (options.FontSize != null)
                 displayPart.Text.FontSize = options.FontSize.Value;
 
-            if (options.ShowCloseButton != null)
-                displayPart.CloseButton.Visibility = options.ShowCloseButton.Value ? Visibility.Visible : Visibility.Collapsed;
+            displayPart.CloseButton.Visibility = options.ShowCloseButton ? Visibility.Visible : Visibility.Collapsed;
         }
     }
 }

--- a/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
+++ b/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
@@ -45,12 +45,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
+++ b/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
@@ -51,7 +51,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d" d:DesignWidth="250" >
 
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource WarningColorBrush}">
-        <Grid x:Name="Content">
+        <Grid x:Name="ContentContainer">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="25" />
                 <ColumnDefinition Width="*" />

--- a/Src/ToastNotifications.Messages/Warning/WarningMessage.cs
+++ b/Src/ToastNotifications.Messages/Warning/WarningMessage.cs
@@ -24,8 +24,7 @@ namespace ToastNotifications.Messages.Warning
             if (options.FontSize != null)
                 displayPart.Text.FontSize = options.FontSize.Value;
 
-            if (options.ShowCloseButton != null)
-                displayPart.CloseButton.Visibility = options.ShowCloseButton.Value ? Visibility.Visible : Visibility.Collapsed;
+            displayPart.CloseButton.Visibility = options.ShowCloseButton ? Visibility.Visible : Visibility.Collapsed;
         }
     }
 }

--- a/Src/ToastNotifications/Core/MessageOptions.cs
+++ b/Src/ToastNotifications/Core/MessageOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using ToastNotifications.Core;
 
 namespace ToastNotifications.Core
 {
@@ -8,6 +7,7 @@ namespace ToastNotifications.Core
         public double? FontSize { get; set; }
 
         public bool? ShowCloseButton { get; set; }
+
         public Action<NotificationBase> NotificationClickAction { get; set; }
 
         public Action<NotificationBase> CloseClickAction { get; set; }
@@ -15,7 +15,5 @@ namespace ToastNotifications.Core
         public object Tag { get; set; }
 
         public bool FreezeOnMouseEnter { get; set; } = true;
-
-
     }
 }

--- a/Src/ToastNotifications/Core/MessageOptions.cs
+++ b/Src/ToastNotifications/Core/MessageOptions.cs
@@ -6,14 +6,14 @@ namespace ToastNotifications.Core
     {
         public double? FontSize { get; set; }
 
-        public bool? ShowCloseButton { get; set; }
-
-        public Action<NotificationBase> NotificationClickAction { get; set; }
-
-        public Action<NotificationBase> CloseClickAction { get; set; }
+        public bool ShowCloseButton { get; set; } = true;
 
         public object Tag { get; set; }
 
         public bool FreezeOnMouseEnter { get; set; } = true;
+
+        public Action<NotificationBase> NotificationClickAction { get; set; }
+
+        public Action<NotificationBase> CloseClickAction { get; set; }
     }
 }

--- a/Src/ToastNotifications/Notifier.cs
+++ b/Src/ToastNotifications/Notifier.cs
@@ -57,6 +57,11 @@ namespace ToastNotifications
             }
         }
 
+        public void ClearMessages()
+        {
+            ClearMessages("");
+        }
+
         public void ClearMessages(string msg)
         {
             this._lifetimeSupervisor?.ClearMessages(msg);

--- a/Src/ToastNotifications/Position/PrimaryScreenPositionProvider.cs
+++ b/Src/ToastNotifications/Position/PrimaryScreenPositionProvider.cs
@@ -90,7 +90,6 @@ namespace ToastNotifications.Position
             // nothing to do here
         }
 
-        // not used in this provider
         public event EventHandler UpdatePositionRequested;
 
         public event EventHandler UpdateEjectDirectionRequested;

--- a/Src/ToastNotifications/Position/WindowPositionProvider.cs
+++ b/Src/ToastNotifications/Position/WindowPositionProvider.cs
@@ -49,7 +49,16 @@ namespace ToastNotifications.Position
 
         public double GetHeight()
         {
-            return ParentWindow.ActualHeight;
+            var actualHeight = (ParentWindow.Content as FrameworkElement)?.ActualHeight ?? ParentWindow.ActualHeight;
+
+            return actualHeight;
+        }
+
+        private double GetWindowHeight()
+        {
+            var actualWidth = (ParentWindow.Content as FrameworkElement)?.ActualWidth ?? ParentWindow.ActualWidth;
+
+            return actualWidth;
         }
 
         private void SetEjectDirection(Corner corner)
@@ -71,12 +80,12 @@ namespace ToastNotifications.Position
 
         private Point GetPositionForBottomLeftCorner(Point parentPosition, double actualPopupWidth, double actualPopupHeight)
         {
-            return new Point(parentPosition.X + _offsetX, parentPosition.Y + ParentWindow.ActualHeight - _offsetY - actualPopupHeight);
+            return new Point(parentPosition.X + _offsetX, parentPosition.Y - _offsetY);
         }
 
         private Point GetPositionForBottomRightCorner(Point parentPosition, double actualPopupWidth, double actualPopupHeight)
         {
-            return new Point(parentPosition.X + ParentWindow.ActualWidth - _offsetX - actualPopupWidth, parentPosition.Y + ParentWindow.ActualHeight - _offsetY - actualPopupHeight);
+            return new Point(parentPosition.X + GetWindowHeight() - _offsetX - actualPopupWidth, parentPosition.Y - _offsetY);
         }
 
         private Point GetPositionForTopLeftCorner(Point parentPosition, double actualPopupWidth, double actualPopupHeight)
@@ -86,7 +95,7 @@ namespace ToastNotifications.Position
 
         private Point GetPositionForTopRightCorner(Point parentPosition, double actualPopupWidth, double actualPopupHeight)
         {
-            return new Point( parentPosition.X + ParentWindow.ActualWidth - _offsetX - actualPopupWidth,  parentPosition.Y + _offsetY);
+            return new Point( parentPosition.X + GetWindowHeight() - _offsetX - actualPopupWidth,  parentPosition.Y + _offsetY);
         }
 
         public void Dispose()

--- a/Src/ToastNotifications/Properties/AssemblyInfo.cs
+++ b/Src/ToastNotifications/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.3.0")]
-[assembly: AssemblyFileVersion("2.1.3.0")]
+[assembly: AssemblyVersion("2.2.0")]
+[assembly: AssemblyFileVersion("2.2.0")]

--- a/Src/ToastNotifications/Properties/AssemblyInfo.cs
+++ b/Src/ToastNotifications/Properties/AssemblyInfo.cs
@@ -10,10 +10,10 @@ using System.Windows;
 [assembly: AssemblyTitle("ToastNotifications")]
 [assembly: AssemblyDescription("Toast notifications for WPF")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("DevCrew.pl Rafa³ £opatka")]
+[assembly: AssemblyCompany("DevCrew.pl Rafaï¿½ ï¿½opatka")]
 [assembly: AssemblyProduct("ToastNotifications")]
-[assembly: AssemblyCopyright("Copyright © Rafa³ £opatka  2017")]
-[assembly: AssemblyTrademark("Rafa³ £opatka")]
+[assembly: AssemblyCopyright("Copyright ï¿½ Rafaï¿½ ï¿½opatka  2017")]
+[assembly: AssemblyTrademark("Rafaï¿½ ï¿½opatka")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0")]
-[assembly: AssemblyFileVersion("2.2.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]

--- a/Src/ToastNotifications/ToastNotifications.csproj
+++ b/Src/ToastNotifications/ToastNotifications.csproj
@@ -45,12 +45,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/Src/ToastNotifications/ToastNotifications.csproj
+++ b/Src/ToastNotifications/ToastNotifications.csproj
@@ -51,7 +51,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>


### PR DESCRIPTION
- fix NotificationDisplayPart.OnMouseEnter - GetOptions() and null check
- Corner enum, added BottomCenter (material design, for control position provider, but work on primary screen and window position provider)
- BasicUsageExample, DisplayOptions.TopMost = false;
- Modified ConfigurationExample dialog - added options